### PR TITLE
fix: font-awesome cdn link unavailable

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -29,7 +29,7 @@
     <%- favicon_tag("static/img/icon.png") %>
     <link rel="icon" href="/static/img/icon.png" sizes="192x192"/>
     <%- css("static/kico.css", "static/hingle.css") %>
-    <%- css("https://cdn.jsdelivr.net/gh/FortAwesome/Font-Awesome/css/font-awesome.min.css") %>
+    <%- css("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css") %>
     <meta name="viewport" content="width=device-width, maximum-scale=1, initial-scale=1"/>
     <meta property="og:site_name" content="<%= config.title %>">
     <meta property="og:title" content="<%= page.title %>"/>


### PR DESCRIPTION
修复 Font-Awesome CDN 链接失效的问题。由于 jsdelivr 在国内某些地区被墙，因此将 CDN 更换为 cdnjs 提供的链接